### PR TITLE
Remove pagination button and add "fetch on scroll" functionality

### DIFF
--- a/public/css/index/index.index.css
+++ b/public/css/index/index.index.css
@@ -154,7 +154,7 @@ ul.categoriesList li:hover,ul.categoriesSubList li:hover {
   text-decoration: underline;
 }
 
-div.paginationBar {
+div.paginationMessage {
   padding-top: 8px;
   padding-bottom: 8px;
   border-bottom: 1px solid #d7d7d7;

--- a/public/js/scrollpagination/jquery.scrollpagination.js
+++ b/public/js/scrollpagination/jquery.scrollpagination.js
@@ -1,0 +1,98 @@
+/*
+ **  Anderson Ferminiano
+ **  contato@andersonferminiano.com -- feel free to contact me for bugs or new implementations.
+ **  jQuery ScrollPagination
+ **  28th/March/2011
+ **  http://andersonferminiano.com/jqueryscrollpagination/
+ **  You may use this script for free, but keep my credits.
+ **  Thank you.
+ */ (function ($) {
+
+
+  $.fn.scrollPagination = function (options) {
+
+    var opts = $.extend($.fn.scrollPagination.defaults, options);
+    var target = opts.scrollTarget;
+    if (target == null) {
+      target = obj;
+    }
+    opts.scrollTarget = target;
+
+    return this.each(function () {
+      $.fn.scrollPagination.init($(this), opts);
+    });
+
+  };
+
+  $.fn.startScrollPagination = function () {
+    return this.each(function () {
+      $(this).prop('scrollPagination', true).trigger('scrollPaginationLoadContent');
+    });
+  };
+
+  $.fn.stopScrollPagination = function () {
+    return this.each(function () {
+      $(this).prop('scrollPagination', false);
+    });
+  };
+
+  $.fn.scrollPagination.loadContent = function (obj, opts) {
+    var target = opts.scrollTarget;
+    var mayLoadContent = $(target).scrollTop() + opts.heightOffset >= $(document).height() - $(target).height();
+    if (mayLoadContent) {
+      if (opts.beforeLoad != null) {
+        opts.beforeLoad();
+      }
+      $(obj).children().attr('rel', 'loaded');
+      contentData = opts.contentData;
+      if ($.isFunction(contentData)) {
+        contentData = opts.contentData();
+      }
+      $.ajax({
+        type: 'POST',
+        url: opts.contentPage,
+        data: contentData,
+        success: function (data) {
+          opts.onSuccess(obj, data);
+          var objectsRendered = $(obj).children('[rel!=loaded]');
+          if (opts.afterLoad != null) {
+            opts.afterLoad(objectsRendered);
+          }
+        },
+        dataType: opts.dataType
+      });
+    }
+
+  };
+
+  $.fn.scrollPagination.init = function (obj, opts) {
+    var target = opts.scrollTarget;
+
+    $(obj).bind('scrollPaginationLoadContent', function () {
+      $.fn.scrollPagination.loadContent($(this), opts);
+    });
+
+    $(target).scroll(function (event) {
+      if ($(obj).prop('scrollPagination')) {
+        $.fn.scrollPagination.loadContent(obj, opts);
+      } else {
+        event.stopPropagation();
+      }
+    });
+
+    $(obj).startScrollPagination();
+  };
+
+  $.fn.scrollPagination.defaults = {
+    'contentPage': null,
+    'contentData': {},
+    'beforeLoad': null,
+    'afterLoad': null,
+    'scrollTarget': null,
+    'heightOffset': 0,
+    'dataType': 'html',
+    'onSuccess': function (obj, data) {
+      $(obj).append(data);
+    }
+  };
+})(jQuery);

--- a/views/index/index.phtml
+++ b/views/index/index.phtml
@@ -13,6 +13,7 @@ PURPOSE.  See the above copyright notices for more information.
 $this->headScript()->appendFile($this->webroot.'/modules/ratings/public/js/star_rating/jquery.ui.stars.min.js');
 $this->headScript()->appendFile($this->moduleWebroot.'/public/js/common/common.js');
 $this->headScript()->appendFile($this->moduleWebroot.'/public/js/index/index.index.js');
+$this->headScript()->appendFile($this->moduleWebroot.'/public/js/scrollpagination/jquery.scrollpagination.js');
 ?>
 <link type="text/css" rel="stylesheet" href="<?php echo $this->moduleWebroot?>/public/css/common/common.css" />
 <link type="text/css" rel="stylesheet" href="<?php echo $this->moduleWebroot?>/public/css/index/index.index.css" />
@@ -65,11 +66,7 @@ else
     </div>
     <div class="extensionsBodyRightColumn">
       <div class="extensionList">
-        <div class="paginationBar">
-          <span id="paginationMessage"></span>
-          <a id="prevPageExtensions" style="display: none;" href="javascript:;">&lt; prev</a>
-          <a id="nextPageExtensions" style="display: none;" href="javascript:;">next &gt;</a>
-        </div>
+        <div class="paginationMessage"></div>
         <div class="loadingExtensions">
           <img alt="" src="<?php echo $this->coreWebroot?>/public/images/icons/loading.gif" /> Loading extensions
         </div>


### PR DESCRIPTION
The initial number of items displayed on the extension list page was fixed
and not all available spaces was used to display items filling the space.

This was confusing for users, indeed the pagination button were not visible
enough and the user wasn't looking for them since the presentation of the
items makes him think that all of them where already fetched.

This commit fulfill two roles: (1) it ensures the available space will be
used to display as much item as possible (See midas.slicerappstore.pageLimit() function)
and (2) it remove the pagination link by using a "fetch items on scroll" mechanism.

The "fetch on scroll" mechanism is implemented with the help of a jquery
plugin developed by "Anderson Ferminiano" and tweaked to allow an easier
integration within ajax based application. Improvements have been contributed
upstream and are waiting to be reviewed. See https://github.com/andferminiano/jquery-scroll-pagination/pull/6
