### PR TITLE
Update "listextensions" controller function so that it expects arch/os/r...

### DIFF
--- a/controllers/IndexController.php
+++ b/controllers/IndexController.php
@@ -71,25 +71,13 @@ class Slicerappstore_IndexController extends Slicerappstore_AppController
       $category = 'any';
       }
     $os = $this->_getParam('os');
-    if(!$os)
-      {
-      $os = 'any';
-      }
     $arch = $this->_getParam('arch');
-    if(!$arch)
-      {
-      $arch = 'any';
-      }
     $release = $this->_getParam('release');
     if(!$release)
       {
       $release = 'any';
       }
     $revision = $this->_getParam('revision');
-    if(!$revision)
-      {
-      $revision = 'any';
-      }
     $limit = $this->_getParam('limit');
     if(!$limit)
       {


### PR DESCRIPTION
...evision

Doing so will avoid returning a mix of extensions belonging to different
"arch", "os" or "revision". When using the interface within midas directly,
the user won't be confused.
