### PR TITLE
Fix category selection when there are no "pageVisibility" support.

### DIFF
--- a/public/js/index/index.index.js
+++ b/public/js/index/index.index.js
@@ -201,7 +201,12 @@ midas.slicerappstore.initScrollPagination = function(){
  */
 midas.slicerappstore.applyFilter = function() {
     midas.slicerappstore.resetFilter();
-    $('#extensionsContainer').startScrollPagination();
+    if ($.support.pageVisibility){
+        $('#extensionsContainer').startScrollPagination();
+    } else {
+        $.fn.scrollPagination.loadContent(
+            $('#extensionsContainer'), midas.slicerappstore.scrollPaginationOptions(/*pageLimit = */ 0), true);
+    }
 }
 
 /**
@@ -327,9 +332,7 @@ $(document).ready(function() {
     }
     else {
       // If visibility API is not supported, fetch all extensions
-      midas.slicerappstore.resetFilter();
-      $.fn.scrollPagination.loadContent(
-          $('#extensionsContainer'), midas.slicerappstore.scrollPaginationOptions(/*pageLimit = */ 0), true);
+      midas.slicerappstore.applyFilter();
     }
 
 });


### PR DESCRIPTION
Resolve Slicer issue 2976. See http://www.na-mic.org/Bug/view.php?id=2976

The recent changes allowing to fetch on demand extensions when scrolling
required to extend the QWebkit object embedded in Slicer so that it
emulates part of the HTML5 Visibility API.

This was done while working on Slicer issue 2911, and the
associated changesets are Slicer r21660 [2] and SlicerAppStore
commit fd86adc7 [3]

When the slicerappstore page is loaded, it checks if the browser
has support for PageVisibility API [4]:

// Setup scroll pagination and fetch results based on the initial settings
if ($.support.pageVisibility){

```
[...]
```

} else {
    // If visibility API is not supported, fetch all extensions

```
[...] // Here is the logic to fetch if no pageVisibility API support
```

}

The problem occurred when clicking on a category. Indeed, the
javascript callback associated with the click event was "applyFilter()"
and this function wasn't checking if the pagevisiblity API was present
and was assuming the "fetch on demand" mode was enabled. Then a
"loading gif" was displayed bu no extension were fetched .. it then give
the impression of "hang".

[1] http://na-mic.org/Mantis/view.php?id=2911
[2] http://viewvc.slicer.org/viewvc.cgi/Slicer4?view=revision&revision=21660
[3] https://github.com/midasplatform/slicerappstore/commit/fd86adc72671858340f881528408b0db181cf2d4
[4] https://github.com/midasplatform/slicerappstore/blob/fd86adc72671858340f881528408b0db181cf2d4/public/js/index/index.index.js#L317
