### PR TITLE
Fix loading of extension when visibility API is not available

### DIFF
--- a/public/js/index/index.index.js
+++ b/public/js/index/index.index.js
@@ -293,23 +293,6 @@ midas.slicerappstore.categoriesLoaded = function () {
         'li#categoryAll' :
         'li.categoryControl[name="'+midas.slicerappstore.category+'"]';
     midas.slicerappstore.selectedCategory = $(selector).addClass('selectedCategory');
-
-    // Setup scroll pagination and fetch results based on the initial settings
-    if ($.support.pageVisibility){
-        if(!midas.slicerappstore.isPageHidden()){
-            midas.slicerappstore.initScrollPagination();
-        } else {
-            $(document).bind("show", function(){
-              midas.slicerappstore.initScrollPagination();
-              $(document).unbind("show");
-            });
-        }
-
-    }
-    else {
-      // If visibility API is not supported, fetch all extensions
-      midas.slicerappstore.applyFilter();
-    }
 };
 
 midas.slicerappstore.fetchCategories = function () {
@@ -374,6 +357,23 @@ $(document).ready(function() {
     }
 
     midas.slicerappstore.fetchCategories();
+
+    // Setup scroll pagination and fetch results based on the initial settings
+    if ($.support.pageVisibility){
+        if(!midas.slicerappstore.isPageHidden()){
+            midas.slicerappstore.initScrollPagination();
+        } else {
+            $(document).bind("show", function(){
+              midas.slicerappstore.initScrollPagination();
+              $(document).unbind("show");
+            });
+        }
+
+    }
+    else {
+      // If visibility API is not supported, fetch all extensions
+      midas.slicerappstore.applyFilter();
+    }
 
     $('img.kwLogo').click(function () {
         var dlgWidth = Math.min($(window).width() * 0.9, 600);


### PR DESCRIPTION
The "update of category count after filtering" introduced by commit 1c4004c
broke the loading of the page in browser not supporting the visibility api.
This impacted both Slicer 4.2.2-1 and regular browser.

Following commit 1c4004c, the function "categoriesLoaded" was both updating
the category cound and setting up the scroll pagination.
In case visibility api wasn't supported, it was calling "applyFilter.
In that particular case, considering that function "fetchCategories" was
called within "applyFilter" and that "applyFilter" was called by
"categoriesLoaded". This was leading to an infinite loop.

This commit move back the setup of the scroll pagination into the document
ready function.

This fixes Slicer issue 3088.
See http://www.na-mic.org/Bug/view.php?id=3088
