### PR TITLE
Fix search icon location

### DIFF
--- a/public/css/common/common.css
+++ b/public/css/common/common.css
@@ -98,7 +98,7 @@ input.extensionField, .extensionSelect select {
 }
 
 input.extensionSearchField {
-    background: white url(/core/public/images/icons/search.png) no-repeat scroll 2px 2px;
+    background: white url("../../../../../core/public/images/icons/search.png") no-repeat scroll 2px 2px;
     padding: 2px 6px 2px 22px;
 }
 


### PR DESCRIPTION
Use relative location for search icon in appstore search field (now that I finally figured out the right number of '../'s needed). This way, the icon is found regardless of the web server's root configuration.
