### PR TITLE
Improve "list element" styling

### DIFF
--- a/public/css/extension/extension.view.css
+++ b/public/css/extension/extension.view.css
@@ -255,24 +255,43 @@ span.addRating {
 }
 
 .screenshotContainer {
-  border: 1px solid gray;
+  float: left;
+
   width: 180px;
   height: 180px;
-  float: left;
-  margin-right: 16px;
-  margin-top: 8px;
-  margin-bottom: 8px;
+  padding: 6px 8px 8px 6px;
+  margin: 0 16px 8px 8px;
+
+  border: 1px solid white;
+
+  -webkit-border-radius: 3px;
+   -khtml-border-radius: 3px;
+     -moz-border-radius: 3px;
+          border-radius: 3px;
+
+  -webkit-transition: all linear 0.2s;
+     -moz-transition: all linear 0.2s;
+          transition: all linear 0.2s;
 }
 
-img.screenshotPreview {  
+img.screenshotPreview {
+  border: 1px solid #ccc;
   cursor: pointer;
+
+  -webkit-box-shadow: 0 1px 4px #555;
+     -moz-box-shadow: 0 1px 4px #555;
+          box-shadow: 0 1px 4px #555;
 }
 
-div.screenshotContainer:hover {
-  -webkit-box-shadow: black 0 0 4px;
-  box-shadow: black 0 0 4px;
-  -moz-box-shadow: 0px 0px 4px black;
+.screenshotContainer:hover {
+  border: 1px solid #d7d7d7;
+  background-color: #f5f5f5;
+
+  -webkit-box-shadow: #ccc 0 0 3px;
+     -moz-box-shadow: #ccc 0 0 3px;
+          box-shadow: #ccc 0 0 3px;
 }
+
 /* ======= END SCREENSHOT SECTION =========*/
 
 .dialogForm {

--- a/public/css/index/index.index.css
+++ b/public/css/index/index.index.css
@@ -70,6 +70,10 @@ div.extensionWrapper {
    -khtml-border-radius: 6px;
      -moz-border-radius: 6px;
           border-radius: 6px;
+
+  -webkit-transition: all linear 0.2s;
+     -moz-transition: all linear 0.2s;
+          transition: all linear 0.2s;
 }
 
 div.extensionIconWrapper img
@@ -83,6 +87,10 @@ div.extensionIconWrapper img
 div.extensionWrapper:hover {
   border: 1px solid #d7d7d7;
   background-color: #f5f5f5;
+
+  -webkit-box-shadow: #ccc 0 0 3px;
+     -moz-box-shadow: #ccc 0 0 3px;
+          box-shadow: #ccc 0 0 3px;
 }
 
 div.extensionNameWrapper,div.subtitleWrapper {


### PR DESCRIPTION
Tweak the styling of extension "list items" slightly to improve appearance (adding a hover effect and a subtle glow on hover). Adjust extension screen shot "list items" to match the extension list, and to give the screen shots a slightly less flat look.
